### PR TITLE
Fix formatting for custom stats

### DIFF
--- a/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
+++ b/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
@@ -46,7 +46,7 @@ limitations under the License.
       .data-custom {
         min-width: 150px;
         max-width: 150px;
-        white-space: normal;
+        white-space: pre-wrap;
         overflow-wrap: break-word;
       }
       #legend-box {

--- a/facets_overview/functional_tests/simple/simple_test.ts
+++ b/facets_overview/functional_tests/simple/simple_test.ts
@@ -91,7 +91,10 @@ function create(): DatasetFeatureStatisticsList {
   const customStats = [th.makeCustomStatistic('customHist', customHist),
                        th.makeCustomStatistic('customNum-reallylongname_testingoverflow', 13.1),
                        th.makeCustomStatistic('customRankHist', customRankHist),
-                       th.makeCustomStatistic('customStr', 'cust')];
+                       th.makeCustomStatistic('customStr', 'cust'),
+                       th.makeCustomStatistic('cStr2', '2021-07-01'),
+                       th.makeCustomStatistic('cStr3', '2021-07-02')
+                      ];
   featureStats.setCustomStatsList(customStats);
   stats.setName('eval');
   data.getDatasetsList().push(stats);


### PR DESCRIPTION
Previously custom stats would word wrap strangely.

Before:

<img width="1066" alt="Screen Shot 2021-08-16 at 2 29 26 PM" src="https://user-images.githubusercontent.com/2577963/129635157-c12ed6de-3225-4970-a9db-fddccdbdfbeb.png">

After:

<img width="1065" alt="Screen Shot 2021-08-16 at 2 32 14 PM" src="https://user-images.githubusercontent.com/2577963/129635176-c137be1e-0cec-431a-a7a7-46d7efba11bb.png">

Testing:

bazel run //facets_overview/functional_tests/simple:devserver
click on index.html